### PR TITLE
Empty torch cache after optimizer tensor replacement

### DIFF
--- a/scene/gaussian_model.py
+++ b/scene/gaussian_model.py
@@ -442,6 +442,8 @@ class GaussianModel:
         self._scaling = optimizable_tensors["scaling"]
         self._rotation = optimizable_tensors["rotation"] 
 
+        torch.cuda.empty_cache()
+        
         return optimizable_tensors
 
     


### PR DESCRIPTION
Without the cache emptying I got really high VRAM usage and was not able to train beyond 1 million Gaussians with 24GB VRAM. Now I can train to over 5 million Gaussians.